### PR TITLE
Improve service worker for offline resilience

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,15 +1,45 @@
 
-const CACHE = "fep-cache-v3";
+const CACHE = "fep-cache-v4";
 const ASSETS = ["./","./index.html","./manifest.json","./icon-192.png","./icon-512.png"];
+
 self.addEventListener("install", (e) => {
+  self.skipWaiting();
   e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
 });
+
 self.addEventListener("activate", (e) => {
-  e.waitUntil(caches.keys().then(keys => Promise.all(keys.filter(k => k!==CACHE).map(k => caches.delete(k)))));
+  clients.claim();
+  e.waitUntil(
+    caches
+      .keys()
+      .then(keys =>
+        Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
+      )
+  );
 });
+
 self.addEventListener("fetch", (e) => {
   const url = new URL(e.request.url);
+  if (e.request.mode === "navigate") {
+    e.respondWith(
+      fetch(e.request).catch(() => caches.match("./index.html"))
+    );
+    return;
+  }
+
   if (url.origin === location.origin) {
-    e.respondWith(caches.match(e.request).then(r => r || fetch(e.request)));
+    e.respondWith(
+      caches.open(CACHE).then(cache =>
+        cache.match(e.request).then(cached => {
+          const fetchPromise = fetch(e.request)
+            .then(res => {
+              cache.put(e.request, res.clone());
+              return res;
+            })
+            .catch(() => cached);
+          return cached || fetchPromise;
+        })
+      )
+    );
   }
 });


### PR DESCRIPTION
## Summary
- use `skipWaiting` on install and `clients.claim` on activate for immediate updates
- add navigation fallback to `index.html` when offline
- switch to stale-while-revalidate strategy for local assets

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d11ee4e08331b14ad1dac36a3c82