### PR TITLE
Load configuration from external file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.js

--- a/README.md
+++ b/README.md
@@ -17,3 +17,25 @@
    - ESCROW_HOURS = 72
 4. In Supabase → SQL Editor → paste schema.sql → Run.
 5. Your app is live at your Vercel URL. Add to home screen on phones for app experience.
+
+## Frontend Configuration
+
+The frontend reads sensitive values from a runtime configuration file.  Copy
+`config.example.js` to `config.js` and provide your own values:
+
+```js
+// config.js
+window.APP_CONFIG = {
+  FORMSPREE: "https://formspree.io/f/your_form_id",
+  EMAILJS_PUBLIC: "your_emailjs_public_key",
+  EMAILJS_SERVICE: "your_emailjs_service_id",
+  EMAILJS_TEMPLATE_SELLER: "template_id_for_seller_notifications",
+  EMAILJS_TEMPLATE_BUYER: "template_id_for_buyer_notifications",
+  API_BASE: "https://your-backend.example.com",
+  STRIPE_PK: "pk_live_your_stripe_publishable_key",
+};
+```
+
+During deployment you can generate this file automatically by injecting
+environment variables. The HTML page simply loads `config.js` and uses the
+values from `window.APP_CONFIG`.

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,9 @@
+window.APP_CONFIG = {
+  FORMSPREE: "https://formspree.io/f/your_form_id",
+  EMAILJS_PUBLIC: "your_emailjs_public_key",
+  EMAILJS_SERVICE: "your_emailjs_service_id",
+  EMAILJS_TEMPLATE_SELLER: "emailjs_template_id_for_seller",
+  EMAILJS_TEMPLATE_BUYER: "emailjs_template_id_for_buyer",
+  API_BASE: "https://your-backend.example.com",
+  STRIPE_PK: "pk_live_your_stripe_publishable_key"
+};

--- a/index.html
+++ b/index.html
@@ -283,6 +283,7 @@
     <p>FandomEntryPass • Installable PWA • Fan-first, fair pricing. Seller notifications required; buyer notifications optional.</p>
   </footer>
 
+  <script src="config.js"></script>
   <script>
     // ======= PWA install + SW =======
     if ("serviceWorker" in navigator) {
@@ -305,20 +306,19 @@
     // ======= CONFIG =======
     const KEY = "fep_listings_v13";
     const ESCROW_HOURS = 72;
-    const FORMSPREE = "https://formspree.io/f/mvgqedqo";
-    const EMAILJS_PUBLIC = "PioDqOAQEpgJXFr7G";
-    const EMAILJS_SERVICE = "service_FEP0";
-    const EMAILJS_TEMPLATE_SELLER = "template_SellerNots";
-    const EMAILJS_TEMPLATE_BUYER = "template_BuyerNots";
+    const {
+      FORMSPREE,
+      EMAILJS_PUBLIC,
+      EMAILJS_SERVICE,
+      EMAILJS_TEMPLATE_SELLER,
+      EMAILJS_TEMPLATE_BUYER,
+      API_BASE,
+      STRIPE_PK,
+    } = window.APP_CONFIG || {};
     const ACCESS_KEY = "fep_gate_ok";
     const ACCESS_CODE = "FEPTEST"; // change anytime
 
-    // Backend base (set to "" if not live yet; when backend is live, set to your domain origin)
-    const API_BASE = "https://fandom-entry-pass-kmj3be28f-alexisdeshong-9388s-projects.vercel.app"; // e.g. "https://yourapp.vercel.app"
-
-    // Stripe publishable key (safe in frontend)
-    const STRIPE_PK = "pk_live_51LcNBuF7BMVtRlnacvmpKOmS9gMBg3IOnkdgaOjdRjCCspQNjHuvPBwLXBdxIn2qC0bJpa1yO2GZjaTbMOvwvr7n00sb6AKo1u";
-    const stripe = Stripe(STRIPE_PK);
+    const stripe = STRIPE_PK ? Stripe(STRIPE_PK) : null;
 
     // ======= ACCESS GATE =======
     function gateCheck() {


### PR DESCRIPTION
## Summary
- Load runtime settings from a `config.js` file instead of hard-coded constants.
- Provide example configuration and document how to supply values.
- Ignore personal `config.js` to avoid committing secrets.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d12e73ac8331a8493f0b7f83b553