### PR TITLE
Handle Formspree attachment field and response errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -683,8 +683,18 @@
       emailFd.append("group", listing.group);
       emailFd.append("date", listing.date);
       emailFd.append("seller_email", listing.sellerEmail);
-      emailFd.append("proof", proofFile, proofFile.name);
-      try { await fetch(FORMSPREE, { method: "POST", body: emailFd, headers: { "Accept": "application/json" } }); } catch {}
+      emailFd.append("attachment", proofFile, proofFile.name);
+      try {
+        const res = await fetch(FORMSPREE, { method: "POST", body: emailFd, headers: { Accept: "application/json" } });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          console.error("Formspree error", err);
+          alert("Failed to send proof. Please try again later.");
+        }
+      } catch (err) {
+        console.error("Formspree error", err);
+        alert("Failed to send proof. Please try again later.");
+      }
       // Save locally (until backend active)
       const current = load(); current.unshift(listing); save(current);
       try { const manageUrl = `${location.origin}${location.pathname}?manage=${editToken}`; await navigator.clipboard.writeText(manageUrl);


### PR DESCRIPTION
## Summary
- update Formspree proof field to `attachment`
- inspect Formspree response and alert on errors

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d4a6aa308331b5a776d435a98664