### PR TITLE
Require contact info and cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,6 +200,11 @@
             <input name="sellerEmail" type="email" required placeholder="you@example.com" class="w-full mt-1 rounded-2xl bg-white px-4 py-3 ring-1 ring-gray-200 outline-none" />
             <p class="text-xs text-gray-500 mt-1">Used for mandatory seller notifications (ticket sold, funds released, auto-release).</p>
           </div>
+          <div class="sm:col-span-3">
+            <label class="text-sm text-gray-600">Seller Phone (required)</label>
+            <input name="sellerPhone" type="tel" required placeholder="555-123-4567" class="w-full mt-1 rounded-2xl bg-white px-4 py-3 ring-1 ring-gray-200 outline-none" />
+            <p class="text-xs text-gray-500 mt-1">Phone number for transaction coordination.</p>
+          </div>
           <div class="sm:col-span-3 flex items-center gap-2 mt-2">
             <input id="agree" type="checkbox" required class="w-4 h-4" />
             <label for="agree" class="text-sm text-gray-700">I agree to fair-pricing rules (+15% cap) and safe transfer.</label>
@@ -253,24 +258,26 @@
     </div>
   </section>
 
-  <!-- Buyer Email Prompt Modal -->
+  <!-- Buyer Contact Info Modal -->
   <section id="buyerModal" class="fixed inset-0 z-[60] hidden">
     <div class="absolute inset-0 bg-black/30"></div>
     <div class="absolute inset-0 flex items-end sm:items-center justify-center p-3">
       <div class="w-full sm:w-[480px] bg-white rounded-3xl shadow-2xl overflow-hidden">
         <div class="gradient-brand p-5 text-white">
-          <h3 class="font-poppins text-xl">Optional Buyer Notifications</h3>
-          <p class="text-white/90 text-sm">Add your email to get escrow status updates (hold, release, 72h fallback).</p>
+          <h3 class="font-poppins text-xl">Buyer Contact Info</h3>
+          <p class="text-white/90 text-sm">We’ll send order updates to this email and phone.</p>
         </div>
         <form id="buyerForm" class="p-5 space-y-4">
           <input type="hidden" name="listingId"/>
           <div>
-            <label class="text-sm text-gray-600">Buyer Email (optional)</label>
-            <input name="buyerEmail" type="email" placeholder="you@example.com" class="w-full mt-1 rounded-2xl bg-white px-4 py-3 ring-1 ring-gray-200 outline-none" />
-            <p class="text-xs text-gray-500 mt-1">We’ll only use this for escrow status emails for this order.</p>
+            <label class="text-sm text-gray-600">Buyer Email</label>
+            <input name="buyerEmail" type="email" required placeholder="you@example.com" class="w-full mt-1 rounded-2xl bg-white px-4 py-3 ring-1 ring-gray-200 outline-none" />
+          </div>
+          <div>
+            <label class="text-sm text-gray-600">Buyer Phone</label>
+            <input name="buyerPhone" type="tel" required placeholder="555-123-4567" class="w-full mt-1 rounded-2xl bg-white px-4 py-3 ring-1 ring-gray-200 outline-none" />
           </div>
           <div class="flex items-center justify-end gap-2 pt-2">
-            <button type="button" id="buyerSkip" class="px-4 py-2 rounded-xl bg-gray-100 hover:bg-gray-200">Skip</button>
             <button class="px-5 py-2 rounded-xl text-white gradient-brand hover:opacity-90">Continue</button>
           </div>
         </form>
@@ -305,6 +312,8 @@
     // ======= CONFIG =======
     const KEY = "fep_listings_v13";
     const ESCROW_HOURS = 72;
+    const TOKEN_TTL_MS = 15 * 60 * 1000;
+    const CONTACT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
     const FORMSPREE = "https://formspree.io/f/mvgqedqo";
     const EMAILJS_PUBLIC = "PioDqOAQEpgJXFr7G";
     const EMAILJS_SERVICE = "service_FEP0";
@@ -349,9 +358,9 @@
     function save(list) { localStorage.setItem(KEY, JSON.stringify(list)); }
     if (!localStorage.getItem(KEY)) {
       const seed = [
-        { id: crypto.randomUUID(), group: "ATEEZ – Atlanta Day 1", date: "Nov 12, 2025 • Gas South Arena", city: "Atlanta", seat: "Sec 104 • Row F • Seat 12", face: 100, price: 118, pay: "#", seller: "Mina", sellerEmail:"mina@example.com", qty: 2, remaining: 2, orders: [] },
-        { id: crypto.randomUUID(), group: "xikers – Orlando", date: "Oct 3, 2025 • Kia Center", city: "Orlando", seat: "Floor • GA", face: 90, price: 95, pay: "#", seller: "Jay", sellerEmail:"jay@example.com", qty: 1, remaining: 1, orders: [] },
-        { id: crypto.randomUUID(), group: "SEVENTEEN – Newark", date: "Dec 2, 2025 • Prudential Center", city: "Newark", seat: "Sec 212 • Row J • Seat 8", face: 85, price: 95, pay: "#", seller: "Ara", sellerEmail:"ara@example.com", qty: 3, remaining: 3, orders: [] },
+        { id: crypto.randomUUID(), group: "ATEEZ – Atlanta Day 1", date: "Nov 12, 2025 • Gas South Arena", city: "Atlanta", seat: "Sec 104 • Row F • Seat 12", face: 100, price: 118, pay: "#", seller: "Mina", sellerEmail:"mina@example.com", sellerPhone:"555-111-0000", qty: 2, remaining: 2, orders: [], lookupToken: token(), lookupExpires: Date.now() + TOKEN_TTL_MS },
+        { id: crypto.randomUUID(), group: "xikers – Orlando", date: "Oct 3, 2025 • Kia Center", city: "Orlando", seat: "Floor • GA", face: 90, price: 95, pay: "#", seller: "Jay", sellerEmail:"jay@example.com", sellerPhone:"555-222-0000", qty: 1, remaining: 1, orders: [], lookupToken: token(), lookupExpires: Date.now() + TOKEN_TTL_MS },
+        { id: crypto.randomUUID(), group: "SEVENTEEN – Newark", date: "Dec 2, 2025 • Prudential Center", city: "Newark", seat: "Sec 212 • Row J • Seat 8", face: 85, price: 95, pay: "#", seller: "Ara", sellerEmail:"ara@example.com", sellerPhone:"555-333-0000", qty: 3, remaining: 3, orders: [], lookupToken: token(), lookupExpires: Date.now() + TOKEN_TTL_MS },
       ];
       save(seed);
     }
@@ -387,7 +396,7 @@
         `City: ${listing.city}`,
         `Seat: ${listing.seat}`,
         `Price: $${listing.price}`,
-        `Seller: ${listing.seller} <${listing.sellerEmail||"-"}>`,
+        `Seller: ${listing.seller} <${listing.sellerEmail||"-"}> (${listing.sellerPhone||"-"})`,
         order ? `Order: ${order.shortId} (${order.status})` : "",
         extra.message || ""
       ].filter(Boolean).join("\n");
@@ -424,7 +433,7 @@
     `Seat: ${listing.seat}\n` +
     `Face: $${listing.face}\n` +
     `Price: $${listing.price}\n` +
-    `Seller: ${listing.seller} <${listing.sellerEmail}>\n` +
+    `Seller: ${listing.seller} <${listing.sellerEmail}> (${listing.sellerPhone})\n` +
     `Qty: ${listing.qty}`;
   form.appendChild(msg);
 
@@ -442,12 +451,12 @@
   setTimeout(() => form.remove(), 3000);
 }
     }
-    async function sellerNotify(listing, subject, text) {
-      if (!listing.sellerEmail) return;
+    async function sellerNotify(listing, order, subject, text) {
+      if (!order.sellerEmail) return;
       try {
         emailjs.init(EMAILJS_PUBLIC);
         await emailjs.send(EMAILJS_SERVICE, EMAILJS_TEMPLATE_SELLER, {
-          to_email: listing.sellerEmail,
+          to_email: order.sellerEmail,
           subject,
           message: text,
           group: listing.group,
@@ -598,19 +607,15 @@
     document.getElementById("closeManage").addEventListener("click", closeManage);
 
     // Buyer modal controls
-    document.getElementById("buyerForm").addEventListener("submit", (e)=>{
-      e.preventDefault();
-      const id = e.target.elements["listingId"].value;
-      const email = String(e.target.elements["buyerEmail"].value || "").trim();
-      closeBuyer();
-      startCheckout(id, email);
-    });
-    document.getElementById("buyerSkip").addEventListener("click", ()=>{
-      const f = document.getElementById("buyerForm");
-      const id = f.elements["listingId"].value;
-      closeBuyer();
-      startCheckout(id, "");
-    });
+      document.getElementById("buyerForm").addEventListener("submit", (e)=>{
+        e.preventDefault();
+        const id = e.target.elements["listingId"].value;
+        const email = String(e.target.elements["buyerEmail"].value || "").trim();
+        const phone = String(e.target.elements["buyerPhone"].value || "").trim();
+        if (!email || !phone) return;
+        closeBuyer();
+        startCheckout(id, email, phone);
+      });
 
     function promptManageByCode() {
       const code = prompt("Enter your 10-character manage code:");
@@ -663,7 +668,8 @@
       const proofFile = fd.get("proof");
       if (!proofFile || !proofFile.size) return alert("Proof of ticket is required. Please upload your proof image.");
       const sellerEmail = String(fd.get("sellerEmail") || "").trim();
-      if (!sellerEmail) return alert("Seller email is required for notifications.");
+      const sellerPhone = String(fd.get("sellerPhone") || "").trim();
+      if (!sellerEmail || !sellerPhone) return alert("Seller email and phone are required for notifications.");
       const editToken = token(); const manageCode = editToken.slice(0,10).toUpperCase();
       const listing = {
         id: crypto.randomUUID(),
@@ -674,15 +680,16 @@
         face, price,
         pay: String(fd.get("pay") || "").trim(),
         seller: String(fd.get("seller") || "Seller").trim(),
-        sellerEmail, qty, remaining: qty, orders: [], editToken, manageCode
+        sellerEmail, sellerPhone, qty, remaining: qty, orders: [], editToken, manageCode, lookupToken: token(), lookupExpires: Date.now() + TOKEN_TTL_MS
       };
       // Email proof to admin via Formspree
       const emailFd = new FormData();
       emailFd.append("_subject", "FEP: New Listing Proof of Ticket");
-      emailFd.append("message", `New listing submitted with proof:\n\nGroup: ${listing.group}\nDate & Venue: ${listing.date}\nCity: ${listing.city}\nSeat: ${listing.seat}\nFace: $${listing.face}\nPrice: $${listing.price}\nSeller: ${listing.seller} <${listing.sellerEmail}>\nQty: ${listing.qty}`);
+      emailFd.append("message", `New listing submitted with proof:\n\nGroup: ${listing.group}\nDate & Venue: ${listing.date}\nCity: ${listing.city}\nSeat: ${listing.seat}\nFace: $${listing.face}\nPrice: $${listing.price}\nSeller: ${listing.seller} <${listing.sellerEmail}> (${sellerPhone})\nQty: ${listing.qty}`);
       emailFd.append("group", listing.group);
       emailFd.append("date", listing.date);
       emailFd.append("seller_email", listing.sellerEmail);
+      emailFd.append("seller_phone", sellerPhone);
       emailFd.append("proof", proofFile, proofFile.name);
       try { await fetch(FORMSPREE, { method: "POST", body: emailFd, headers: { "Accept": "application/json" } }); } catch {}
       // Save locally (until backend active)
@@ -698,7 +705,7 @@
       const f = document.getElementById("buyerForm"); f.reset();
       f.elements["listingId"].value = listingId; openBuyer();
     }
-    async function startCheckout(listingId, buyerEmail) {
+    async function startCheckout(listingId, buyerEmail, buyerPhone) {
       const list = load();
       const it = list.find(x=>x.id===listingId);
       if (!it) return alert("Listing not found."); if (it.remaining <= 0) return alert("Sold out.");
@@ -709,7 +716,7 @@
           const res = await fetch(`${API_BASE}/api/orders`, {
             method: "POST",
             headers: { "Content-Type":"application/json" },
-            body: JSON.stringify({ listingId, buyerEmail })
+            body: JSON.stringify({ listingId, buyerEmail, buyerPhone })
           });
           if (!res.ok) throw new Error("Order create failed");
           const data = await res.json();
@@ -723,10 +730,10 @@
       // Open seller's pay link in new tab (manual for MVP; replace with Stripe checkout later)
       if (it.pay && it.pay !== "#") window.open(it.pay, "_blank");
 
-      const order = { id: crypto.randomUUID(), shortId: Math.random().toString(36).slice(2,6).toUpperCase(), status: "authorized", authorizedAt: Date.now(), releasedAt: null, buyerEmail: buyerEmail || "" };
+      const order = { id: crypto.randomUUID(), shortId: Math.random().toString(36).slice(2,6).toUpperCase(), lookupToken: token(), lookupExpires: Date.now() + TOKEN_TTL_MS, status: "authorized", authorizedAt: Date.now(), releasedAt: null, buyerEmail, buyerPhone, sellerEmail: it.sellerEmail || "", sellerPhone: it.sellerPhone || "" };
       it.orders.push(order); it.remaining -= 1; save(list);
       adminNotify("order_authorized_sim", it, order);
-      sellerNotify(it, "Ticket sold (authorized)", `Order ${order.shortId} for ${it.group} is authorized. Remember to transfer the ticket.`);
+      sellerNotify(it, order, "Ticket sold (authorized)", `Order ${order.shortId} for ${it.group} is authorized. Remember to transfer the ticket.`);
       buyerNotify(it, order, "Purchase received – funds on hold", `We’ve placed your payment for order ${order.shortId} in escrow for up to 72 hours while the ticket is transferred.`);
       applyFilters();
     }
@@ -735,7 +742,7 @@
       outer: for (const it of list) { for (const o of it.orders) {
           if (o.id === orderId) { o.status = "released"; o.releasedAt = Date.now();
             adminNotify("order_released_manual_sim", it, o);
-            sellerNotify(it, "Funds released", `Order ${o.shortId} for ${it.group} has been released to you.`);
+            sellerNotify(it, o, "Funds released", `Order ${o.shortId} for ${it.group} has been released to you.`);
             buyerNotify(it, o, "Escrow released", `Your confirmation released funds for order ${o.shortId}. Enjoy the show!`);
             break outer; } } }
       save(list); applyFilters();
@@ -753,7 +760,7 @@
               o.status = "released";
               o.releasedAt = Date.now();
               adminNotify("order_released_auto", it, o);
-              sellerNotify(it, "Funds released (auto)", `Order ${o.shortId} for ${it.group} was auto-released after 72h.`);
+              sellerNotify(it, o, "Funds released (auto)", `Order ${o.shortId} for ${it.group} was auto-released after 72h.`);
               buyerNotify(it, o, "Escrow auto-released", `Your order ${o.shortId} was auto-released after 72h.`);
               changed = true;
             }
@@ -768,6 +775,28 @@
       }
     }
     setInterval(tick, 1000);
+
+    function purgeContacts() {
+      const list = load();
+      let changed = false;
+      const now = Date.now();
+      for (const it of list) {
+        for (const o of (it.orders||[])) {
+          if (o.lookupExpires && now > o.lookupExpires) { delete o.lookupToken; delete o.lookupExpires; changed = true; }
+          if (o.status === "released" && o.releasedAt && now - o.releasedAt > CONTACT_RETENTION_MS && !o.contactPurged) {
+            delete o.buyerEmail; delete o.buyerPhone; delete o.sellerEmail; delete o.sellerPhone;
+            o.contactPurged = true; changed = true;
+          }
+        }
+        if (it.lookupExpires && now > it.lookupExpires) { delete it.lookupToken; delete it.lookupExpires; changed = true; }
+        if (it.orders && it.orders.length && it.orders.every(o=>o.contactPurged)) {
+          delete it.sellerEmail; delete it.sellerPhone;
+        }
+      }
+      if (changed) save(list);
+    }
+    setInterval(purgeContacts, hoursMs(1));
+    purgeContacts();
 
     (function init(){
       try { emailjs.init(EMAILJS_PUBLIC); } catch {}


### PR DESCRIPTION
## Summary
- require email and phone for sellers and buyers, storing details on each order
- add lookup tokens with short TTL for listings and orders
- periodically purge expired tokens and contact info after payouts

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e05eea988331acf41e05e4022676