### PR TITLE
Remove duplicate service worker registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -845,7 +845,6 @@
 
     (function init(){
       try { emailjs.init(EMAILJS_PUBLIC); } catch {}
-      if ("serviceWorker" in navigator) navigator.serviceWorker.register("./service-worker.js");
       gateCheck();
       applyFilters();
       const u = new URL(window.location.href); const manage = u.searchParams.get("manage") || "";


### PR DESCRIPTION
## Summary
- remove redundant service worker registration inside `init` function in `index.html`

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b49d8a80833184cb792d636e0f45