### PR TITLE
Allow configuring escrow duration

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -5,5 +5,6 @@ window.APP_CONFIG = {
   EMAILJS_TEMPLATE_SELLER: "emailjs_template_id_for_seller",
   EMAILJS_TEMPLATE_BUYER: "emailjs_template_id_for_buyer",
   API_BASE: "https://your-backend.example.com",
-  STRIPE_PK: "pk_live_your_stripe_publishable_key"
+  STRIPE_PK: "pk_live_your_stripe_publishable_key",
+  ESCROW_HOURS: 72,
 };

--- a/index.html
+++ b/index.html
@@ -305,7 +305,6 @@
 
     // ======= CONFIG =======
     const KEY = "fep_listings_v13";
-    const ESCROW_HOURS = 72;
     const {
       FORMSPREE,
       EMAILJS_PUBLIC,
@@ -314,6 +313,7 @@
       EMAILJS_TEMPLATE_BUYER,
       API_BASE,
       STRIPE_PK,
+      ESCROW_HOURS = 72,
     } = window.APP_CONFIG || {};
     const ACCESS_KEY = "fep_gate_ok";
     const ACCESS_CODE = "FEPTEST"; // change anytime


### PR DESCRIPTION
## Summary
- Read escrow duration from `window.APP_CONFIG` with a default of 72 hours
- Expose `ESCROW_HOURS` in `config.example.js` so deployments can override it

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b53d319883319029ab16bf605618