### PR TITLE
Persist listings to backend with admin approval workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,22 @@
 1. Upload all files to your GitHub repo (root).
 2. Connect repo to Vercel → New Project → Framework: Other → Deploy.
 3. In Vercel Settings → Environment Variables, add:
-   - DATABASE_URL (from Supabase)
+   - SUPABASE_URL (from Supabase project)
+   - SUPABASE_SERVICE_KEY (service role key)
+   - ADMIN_TOKEN (secret for admin approval API)
    - STRIPE_SECRET_KEY (your Stripe live secret key)
    - STRIPE_WEBHOOK_SECRET (from Stripe dashboard after making webhook)
    - FEP_PLATFORM_FEE_FLAT_CENTS = 350
    - FEP_SELLER_FEE_BPS = 500
    - ESCROW_HOURS = 72
-4. In Supabase → SQL Editor → paste schema.sql → Run.
+4. In Supabase → SQL Editor → paste schema.sql → Run. Also create a storage bucket named `proofs` for uploaded ticket images.
 5. Your app is live at your Vercel URL. Add to home screen on phones for app experience.
+
+## Admin Approval
+Listings submitted by sellers are stored with `status = pending` and are not shown to buyers until approved. Approve a listing via:
+```
+POST /api/admin/approve
+Authorization: Bearer <ADMIN_TOKEN>
+Body: { "id": "<listing-id>" }
+```
+Approved listings are returned by `GET /api/listings`.

--- a/api/admin/approve.js
+++ b/api/admin/approve.js
@@ -1,0 +1,16 @@
+const { createClient } = require('@supabase/supabase-js');
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN;
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') return res.status(405).end();
+  if (!ADMIN_TOKEN || req.headers.authorization !== `Bearer ${ADMIN_TOKEN}`) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  const { id } = req.body || {};
+  if (!id) return res.status(400).json({ error: 'Missing id' });
+  const { error } = await supabase.from('listings').update({ status: 'approved' }).eq('id', id);
+  if (error) return res.status(500).json({ error: error.message });
+  res.json({ success: true });
+};

--- a/api/listings.js
+++ b/api/listings.js
@@ -1,0 +1,60 @@
+const { createClient } = require('@supabase/supabase-js');
+const crypto = require('crypto');
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+
+module.exports = async (req, res) => {
+  if (req.method === 'POST') {
+    try {
+      const body = req.body || {};
+      const {
+        proof, proofName, proofType,
+        ...fields
+      } = body;
+      const id = fields.id || crypto.randomUUID();
+      let proofUrl = null;
+      if (proof) {
+        const buffer = Buffer.from(proof, 'base64');
+        const path = `${id}/${proofName || 'proof'}`;
+        const { error: uploadErr } = await supabase.storage
+          .from('proofs')
+          .upload(path, buffer, { contentType: proofType || 'application/octet-stream' });
+        if (uploadErr) return res.status(500).json({ error: uploadErr.message });
+        const { data: urlData } = supabase.storage.from('proofs').getPublicUrl(path);
+        proofUrl = urlData.publicUrl;
+      }
+      const { error } = await supabase.from('listings').insert([{
+        id,
+        group: fields.group,
+        date: fields.date,
+        city: fields.city,
+        seat: fields.seat,
+        face: fields.face,
+        price: fields.price,
+        pay: fields.pay,
+        seller: fields.seller,
+        seller_email: fields.sellerEmail,
+        qty: fields.qty,
+        remaining: fields.qty,
+        edit_token: fields.editToken,
+        manage_code: fields.manageCode,
+        proof_url: proofUrl,
+        status: 'pending'
+      }]);
+      if (error) return res.status(500).json({ error: error.message });
+      return res.status(201).json({ id, status: 'pending' });
+    } catch (e) {
+      return res.status(400).json({ error: 'Invalid request' });
+    }
+  }
+  if (req.method === 'GET') {
+    const { data, error } = await supabase
+      .from('listings')
+      .select('*')
+      .eq('status', 'approved')
+      .order('created_at', { ascending: false });
+    if (error) return res.status(500).json({ error: error.message });
+    return res.status(200).json(data);
+  }
+  res.status(405).end();
+};

--- a/index.html
+++ b/index.html
@@ -344,16 +344,19 @@
       else { alert("Wrong code"); }
     });
 
-    // ======= STORAGE (local demo until backend is connected) =======
+    // ======= STORAGE =======
     function load() { try { return JSON.parse(localStorage.getItem(KEY) || "null") || []; } catch { return []; } }
     function save(list) { localStorage.setItem(KEY, JSON.stringify(list)); }
-    if (!localStorage.getItem(KEY)) {
-      const seed = [
-        { id: crypto.randomUUID(), group: "ATEEZ – Atlanta Day 1", date: "Nov 12, 2025 • Gas South Arena", city: "Atlanta", seat: "Sec 104 • Row F • Seat 12", face: 100, price: 118, pay: "#", seller: "Mina", sellerEmail:"mina@example.com", qty: 2, remaining: 2, orders: [] },
-        { id: crypto.randomUUID(), group: "xikers – Orlando", date: "Oct 3, 2025 • Kia Center", city: "Orlando", seat: "Floor • GA", face: 90, price: 95, pay: "#", seller: "Jay", sellerEmail:"jay@example.com", qty: 1, remaining: 1, orders: [] },
-        { id: crypto.randomUUID(), group: "SEVENTEEN – Newark", date: "Dec 2, 2025 • Prudential Center", city: "Newark", seat: "Sec 212 • Row J • Seat 8", face: 85, price: 95, pay: "#", seller: "Ara", sellerEmail:"ara@example.com", qty: 3, remaining: 3, orders: [] },
-      ];
-      save(seed);
+    async function syncListings() {
+      if (!API_BASE) return;
+      try {
+        const res = await fetch(`${API_BASE}/api/listings`);
+        if (!res.ok) throw new Error('bad');
+        const serverList = await res.json();
+        const local = load();
+        const pending = local.filter(l => l.status === 'pending' && !serverList.find(s => s.id === l.id));
+        save([...serverList, ...pending]);
+      } catch (e) { console.warn('syncListings failed', e); }
     }
 
     // ======= HELPERS =======
@@ -559,7 +562,7 @@
       const city = document.getElementById("city").value.trim().toLowerCase();
       const maxPrice = Number(document.getElementById("maxPrice").value || Infinity);
 
-      const list = load().filter(it => {
+        const list = load().filter(it => it.status === 'approved').filter(it => {
         const hay = (it.group + " " + it.date + " " + (it.city || "")).toLowerCase();
         const matchQ = !q || hay.includes(q);
         const matchCity = !city || (it.city || "").toLowerCase().includes(city);
@@ -674,23 +677,32 @@
         face, price,
         pay: String(fd.get("pay") || "").trim(),
         seller: String(fd.get("seller") || "Seller").trim(),
-        sellerEmail, qty, remaining: qty, orders: [], editToken, manageCode
+        sellerEmail, qty, remaining: qty, orders: [], editToken, manageCode, status: "pending"
       };
-      // Email proof to admin via Formspree
-      const emailFd = new FormData();
-      emailFd.append("_subject", "FEP: New Listing Proof of Ticket");
-      emailFd.append("message", `New listing submitted with proof:\n\nGroup: ${listing.group}\nDate & Venue: ${listing.date}\nCity: ${listing.city}\nSeat: ${listing.seat}\nFace: $${listing.face}\nPrice: $${listing.price}\nSeller: ${listing.seller} <${listing.sellerEmail}>\nQty: ${listing.qty}`);
-      emailFd.append("group", listing.group);
-      emailFd.append("date", listing.date);
-      emailFd.append("seller_email", listing.sellerEmail);
-      emailFd.append("proof", proofFile, proofFile.name);
-      try { await fetch(FORMSPREE, { method: "POST", body: emailFd, headers: { "Accept": "application/json" } }); } catch {}
-      // Save locally (until backend active)
+      const proofBase64 = await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result.split(',')[1]);
+        reader.onerror = reject;
+        reader.readAsDataURL(proofFile);
+      });
+      try {
+        await fetch(`${API_BASE}/api/listings`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...listing, proof: proofBase64, proofName: proofFile.name, proofType: proofFile.type })
+        });
+      } catch (err) {
+        return alert("Failed to submit listing. Please try again later.");
+      }
       const current = load(); current.unshift(listing); save(current);
-      try { const manageUrl = `${location.origin}${location.pathname}?manage=${editToken}`; await navigator.clipboard.writeText(manageUrl);
-        alert("Listing created!\n\nSeller manage code: " + manageCode + "\n(Manage link copied to clipboard.)");
-      } catch { alert("Listing created!\n\nSeller manage code: " + manageCode); }
-      closeModal(); e.target.reset(); applyFilters(); window.scrollTo({ top: 0, behavior: "smooth" });
+      try {
+        const manageUrl = `${location.origin}${location.pathname}?manage=${editToken}`;
+        await navigator.clipboard.writeText(manageUrl);
+        alert("Listing submitted!\n\nSeller manage code: " + manageCode + "\n(Manage link copied to clipboard.)");
+      } catch {
+        alert("Listing submitted!\n\nSeller manage code: " + manageCode);
+      }
+      closeModal(); e.target.reset(); await syncListings(); applyFilters(); window.scrollTo({ top: 0, behavior: "smooth" });
     });
 
     // ======= BUYER FLOW =======
@@ -769,10 +781,11 @@
     }
     setInterval(tick, 1000);
 
-    (function init(){
+    (async function init(){
       try { emailjs.init(EMAILJS_PUBLIC); } catch {}
       if ("serviceWorker" in navigator) navigator.serviceWorker.register("./service-worker.js");
       gateCheck();
+      await syncListings();
       applyFilters();
       const u = new URL(window.location.href); const manage = u.searchParams.get("manage") || "";
       if (manage) { const it = load().find(x=>x.editToken === manage); if (it) { fillManageForm(it); openManage(); } }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fandom-entry-pass",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.0"
+  }
+}

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,19 @@
+create table if not exists listings (
+  id uuid primary key,
+  "group" text not null,
+  date text not null,
+  city text,
+  seat text,
+  face numeric,
+  price numeric,
+  pay text,
+  seller text,
+  seller_email text,
+  qty integer,
+  remaining integer,
+  edit_token text,
+  manage_code text,
+  proof_url text,
+  status text default 'pending',
+  created_at timestamptz default now()
+);


### PR DESCRIPTION
## Summary
- store new listings and proof uploads in Supabase via `/api/listings`
- add admin approval endpoint to publish pending listings
- frontend syncs approved listings from backend and hides pending entries

## Testing
- `node --check api/listings.js`
- `node --check api/admin/approve.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7d97713788331bc206205173f649d