### PR TITLE
Recreate package.json using npm init

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "fandom-entry-pass",
   "version": "1.0.0",
-  "description": "Short description of the project",
-  "main": "index.js",
+  "description": "- Frontend PWA: index.html + manifest + service-worker + icons",
+  "main": "config.example.js",
   "scripts": {
-    "start": "node index.js",
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",
-  "license": "MIT"
+  "license": "ISC",
+  "type": "commonjs"
 }


### PR DESCRIPTION
## Summary
- Regenerate package.json with `npm init -y` to ensure proper JSON formatting and scripts.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx vercel --prod` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bccd328883319e533cbae11b7c45