### PR TITLE
fix: point package entry to server.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fandom-entry-pass",
   "version": "1.0.0",
   "description": "- Frontend PWA: index.html + manifest + service-worker + icons",
-  "main": "config.example.js",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js"


### PR DESCRIPTION
## Summary
- set package.json main to server.js
- ensure start script runs node server.js

## Testing
- `npm test` (fails: Error: no test specified)
- `npm start` (fails: Cannot find module 'express`

------
https://chatgpt.com/codex/tasks/task_e_68b8bfc647988331be56c482d1e6ed18