### PR TITLE
feat: secure order tokens and contact retention

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
       <div class="w-full sm:w-[860px] bg-white rounded-3xl shadow-2xl overflow-hidden">
         <div class="gradient-brand p-5 text-white">
           <h3 class="font-poppins text-xl">Add a Listing</h3>
-          <p class="text-white/90 text-sm">Blur barcodes on proof images. Above +15% is blocked. Seller email is required for notifications.</p>
+          <p class="text-white/90 text-sm">Blur barcodes on proof images. Above +15% is blocked. Seller email and phone are required for notifications.</p>
         </div>
         <form id="addForm" class="p-5 grid grid-cols-1 sm:grid-cols-3 gap-4">
           <div class="sm:col-span-2">
@@ -194,6 +194,11 @@
           <div>
             <label class="text-sm text-gray-600">Seller Name</label>
             <input name="seller" placeholder="Mina" class="w-full mt-1 rounded-2xl bg-white px-4 py-3 ring-1 ring-gray-200 focus:ring-sky-300 outline-none" />
+          </div>
+          <div class="sm:col-span-3">
+            <label class="text-sm text-gray-600">Seller Phone (required)</label>
+            <input name="sellerPhone" type="tel" required placeholder="555-123-4567" class="w-full mt-1 rounded-2xl bg-white px-4 py-3 ring-1 ring-gray-200 outline-none" />
+            <p class="text-xs text-gray-500 mt-1">Used for mandatory seller notifications.</p>
           </div>
           <div class="sm:col-span-3">
             <label class="text-sm text-gray-600">Seller Email (required)</label>
@@ -253,24 +258,26 @@
     </div>
   </section>
 
-  <!-- Buyer Email Prompt Modal -->
+  <!-- Buyer Contact Modal -->
   <section id="buyerModal" class="fixed inset-0 z-[60] hidden">
     <div class="absolute inset-0 bg-black/30"></div>
     <div class="absolute inset-0 flex items-end sm:items-center justify-center p-3">
       <div class="w-full sm:w-[480px] bg-white rounded-3xl shadow-2xl overflow-hidden">
         <div class="gradient-brand p-5 text-white">
-          <h3 class="font-poppins text-xl">Optional Buyer Notifications</h3>
-          <p class="text-white/90 text-sm">Add your email to get escrow status updates (hold, release, 72h fallback).</p>
+          <h3 class="font-poppins text-xl">Buyer Contact</h3>
+          <p class="text-white/90 text-sm">Add your email and phone to get escrow status updates.</p>
         </div>
         <form id="buyerForm" class="p-5 space-y-4">
           <input type="hidden" name="listingId"/>
           <div>
-            <label class="text-sm text-gray-600">Buyer Email (optional)</label>
-            <input name="buyerEmail" type="email" placeholder="you@example.com" class="w-full mt-1 rounded-2xl bg-white px-4 py-3 ring-1 ring-gray-200 outline-none" />
-            <p class="text-xs text-gray-500 mt-1">We’ll only use this for escrow status emails for this order.</p>
+            <label class="text-sm text-gray-600">Buyer Email <span class="text-rose-500">*</span></label>
+            <input name="buyerEmail" type="email" required placeholder="you@example.com" class="w-full mt-1 rounded-2xl bg-white px-4 py-3 ring-1 ring-gray-200 outline-none" />
+          </div>
+          <div>
+            <label class="text-sm text-gray-600">Buyer Phone <span class="text-rose-500">*</span></label>
+            <input name="buyerPhone" type="tel" required placeholder="555-123-4567" class="w-full mt-1 rounded-2xl bg-white px-4 py-3 ring-1 ring-gray-200 outline-none" />
           </div>
           <div class="flex items-center justify-end gap-2 pt-2">
-            <button type="button" id="buyerSkip" class="px-4 py-2 rounded-xl bg-gray-100 hover:bg-gray-200">Skip</button>
             <button class="px-5 py-2 rounded-xl text-white gradient-brand hover:opacity-90">Continue</button>
           </div>
         </form>
@@ -280,7 +287,7 @@
 
   <!-- Footer -->
   <footer class="mt-10 py-10 text-center text-sm text-gray-500">
-    <p>FandomEntryPass • Installable PWA • Fan-first, fair pricing. Seller notifications required; buyer notifications optional.</p>
+    <p>FandomEntryPass • Installable PWA • Fan-first, fair pricing. Buyer and seller contact required; data purged after payout.</p>
   </footer>
 
   <script>
@@ -303,8 +310,9 @@
     });
 
     // ======= CONFIG =======
-    const KEY = "fep_listings_v13";
+    const KEY = "fep_listings_v14";
     const ESCROW_HOURS = 72;
+    const RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
     const FORMSPREE = "https://formspree.io/f/mvgqedqo";
     const EMAILJS_PUBLIC = "PioDqOAQEpgJXFr7G";
     const EMAILJS_SERVICE = "service_FEP0";
@@ -349,9 +357,9 @@
     function save(list) { localStorage.setItem(KEY, JSON.stringify(list)); }
     if (!localStorage.getItem(KEY)) {
       const seed = [
-        { id: crypto.randomUUID(), group: "ATEEZ – Atlanta Day 1", date: "Nov 12, 2025 • Gas South Arena", city: "Atlanta", seat: "Sec 104 • Row F • Seat 12", face: 100, price: 118, pay: "#", seller: "Mina", sellerEmail:"mina@example.com", qty: 2, remaining: 2, orders: [] },
-        { id: crypto.randomUUID(), group: "xikers – Orlando", date: "Oct 3, 2025 • Kia Center", city: "Orlando", seat: "Floor • GA", face: 90, price: 95, pay: "#", seller: "Jay", sellerEmail:"jay@example.com", qty: 1, remaining: 1, orders: [] },
-        { id: crypto.randomUUID(), group: "SEVENTEEN – Newark", date: "Dec 2, 2025 • Prudential Center", city: "Newark", seat: "Sec 212 • Row J • Seat 8", face: 85, price: 95, pay: "#", seller: "Ara", sellerEmail:"ara@example.com", qty: 3, remaining: 3, orders: [] },
+        { id: crypto.randomUUID(), group: "ATEEZ – Atlanta Day 1", date: "Nov 12, 2025 • Gas South Arena", city: "Atlanta", seat: "Sec 104 • Row F • Seat 12", face: 100, price: 118, pay: "#", seller: "Mina", sellerEmail:"mina@example.com", sellerPhone:"555-000-1000", qty: 2, remaining: 2, orders: [] },
+        { id: crypto.randomUUID(), group: "xikers – Orlando", date: "Oct 3, 2025 • Kia Center", city: "Orlando", seat: "Floor • GA", face: 90, price: 95, pay: "#", seller: "Jay", sellerEmail:"jay@example.com", sellerPhone:"555-000-2000", qty: 1, remaining: 1, orders: [] },
+        { id: crypto.randomUUID(), group: "SEVENTEEN – Newark", date: "Dec 2, 2025 • Prudential Center", city: "Newark", seat: "Sec 212 • Row J • Seat 8", face: 85, price: 95, pay: "#", seller: "Ara", sellerEmail:"ara@example.com", sellerPhone:"555-000-3000", qty: 3, remaining: 3, orders: [] },
       ];
       save(seed);
     }
@@ -374,6 +382,11 @@
       const s = Math.floor((ms%60000)/1000);
       return `${h}h ${m}m ${s}s`;
     }
+    function purgeOrder(o) {
+      delete o.buyerEmail; delete o.buyerPhone;
+      delete o.sellerEmail; delete o.sellerPhone;
+      delete o.token; delete o.tokenExpiresAt;
+    }
     function token() { return Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2); }
 
     // ======= NOTIFICATIONS =======
@@ -387,8 +400,9 @@
         `City: ${listing.city}`,
         `Seat: ${listing.seat}`,
         `Price: $${listing.price}`,
-        `Seller: ${listing.seller} <${listing.sellerEmail||"-"}>`,
-        order ? `Order: ${order.shortId} (${order.status})` : "",
+        `Seller: ${listing.seller} <${(order && order.sellerEmail) || listing.sellerEmail || "-"}>${order && order.sellerPhone ? ` (${order.sellerPhone})` : ""}`,
+        order ? `Buyer: ${(order.buyerEmail||"-")} ${order.buyerPhone?`(${order.buyerPhone})`:""}` : "",
+        order ? `Order: ${order.token ? order.token.slice(0,8) : ""} (${order.status})` : "",
         extra.message || ""
       ].filter(Boolean).join("\n");
       fd.append("message", msg);
@@ -424,7 +438,7 @@
     `Seat: ${listing.seat}\n` +
     `Face: $${listing.face}\n` +
     `Price: $${listing.price}\n` +
-    `Seller: ${listing.seller} <${listing.sellerEmail}>\n` +
+    `Seller: ${listing.seller} <${listing.sellerEmail}> (${listing.sellerPhone})\n` +
     `Qty: ${listing.qty}`;
   form.appendChild(msg);
 
@@ -442,12 +456,12 @@
   setTimeout(() => form.remove(), 3000);
 }
     }
-    async function sellerNotify(listing, subject, text) {
-      if (!listing.sellerEmail) return;
+    async function sellerNotify(listing, order, subject, text) {
+      if (!order.sellerEmail) return;
       try {
         emailjs.init(EMAILJS_PUBLIC);
         await emailjs.send(EMAILJS_SERVICE, EMAILJS_TEMPLATE_SELLER, {
-          to_email: listing.sellerEmail,
+          to_email: order.sellerEmail,
           subject,
           message: text,
           group: listing.group,
@@ -486,17 +500,18 @@
         let ordersHtml = "";
         if (it.orders && it.orders.length) {
           ordersHtml = `<div class="mt-3 space-y-2">` + it.orders.map(o => {
+            const code = o.token ? o.token.slice(0,8) : "";
             if (o.status === "authorized") {
               return `
               <div class="rounded-xl bg-amber-50 border border-amber-200 p-2 text-[12px] text-amber-900">
-                Order ${o.shortId} • Authorized • Auto-release in
+                Order ${code} • Authorized • Auto-release in
                 <span data-countdown="${o.id}">${fmt(timeLeftMs(o))}</span>
                 <button data-confirm="${o.id}" class="ml-2 rounded-lg px-2 py-0.5 bg-emerald-600 text-white">Confirm Received → Release</button>
               </div>`;
             } else {
               return `
               <div class="rounded-xl bg-emerald-50 border border-emerald-200 p-2 text-[12px] text-emerald-900">
-                Order ${o.shortId} • ✅ Released to seller.
+                Order ${code} • ✅ Released to seller.
               </div>`;
             }
           }).join("") + `</div>`;
@@ -602,14 +617,10 @@
       e.preventDefault();
       const id = e.target.elements["listingId"].value;
       const email = String(e.target.elements["buyerEmail"].value || "").trim();
+      const phone = String(e.target.elements["buyerPhone"].value || "").trim();
+      if (!email || !phone) return alert("Buyer email and phone are required.");
       closeBuyer();
-      startCheckout(id, email);
-    });
-    document.getElementById("buyerSkip").addEventListener("click", ()=>{
-      const f = document.getElementById("buyerForm");
-      const id = f.elements["listingId"].value;
-      closeBuyer();
-      startCheckout(id, "");
+      startCheckout(id, email, phone);
     });
 
     function promptManageByCode() {
@@ -663,7 +674,8 @@
       const proofFile = fd.get("proof");
       if (!proofFile || !proofFile.size) return alert("Proof of ticket is required. Please upload your proof image.");
       const sellerEmail = String(fd.get("sellerEmail") || "").trim();
-      if (!sellerEmail) return alert("Seller email is required for notifications.");
+      const sellerPhone = String(fd.get("sellerPhone") || "").trim();
+      if (!sellerEmail || !sellerPhone) return alert("Seller email and phone are required for notifications.");
       const editToken = token(); const manageCode = editToken.slice(0,10).toUpperCase();
       const listing = {
         id: crypto.randomUUID(),
@@ -674,15 +686,16 @@
         face, price,
         pay: String(fd.get("pay") || "").trim(),
         seller: String(fd.get("seller") || "Seller").trim(),
-        sellerEmail, qty, remaining: qty, orders: [], editToken, manageCode
+        sellerEmail, sellerPhone, qty, remaining: qty, orders: [], editToken, manageCode
       };
       // Email proof to admin via Formspree
       const emailFd = new FormData();
       emailFd.append("_subject", "FEP: New Listing Proof of Ticket");
-      emailFd.append("message", `New listing submitted with proof:\n\nGroup: ${listing.group}\nDate & Venue: ${listing.date}\nCity: ${listing.city}\nSeat: ${listing.seat}\nFace: $${listing.face}\nPrice: $${listing.price}\nSeller: ${listing.seller} <${listing.sellerEmail}>\nQty: ${listing.qty}`);
+      emailFd.append("message", `New listing submitted with proof:\n\nGroup: ${listing.group}\nDate & Venue: ${listing.date}\nCity: ${listing.city}\nSeat: ${listing.seat}\nFace: $${listing.face}\nPrice: $${listing.price}\nSeller: ${listing.seller} <${listing.sellerEmail}> (${listing.sellerPhone})\nQty: ${listing.qty}`);
       emailFd.append("group", listing.group);
       emailFd.append("date", listing.date);
       emailFd.append("seller_email", listing.sellerEmail);
+      emailFd.append("seller_phone", listing.sellerPhone);
       emailFd.append("proof", proofFile, proofFile.name);
       try { await fetch(FORMSPREE, { method: "POST", body: emailFd, headers: { "Accept": "application/json" } }); } catch {}
       // Save locally (until backend active)
@@ -698,7 +711,7 @@
       const f = document.getElementById("buyerForm"); f.reset();
       f.elements["listingId"].value = listingId; openBuyer();
     }
-    async function startCheckout(listingId, buyerEmail) {
+    async function startCheckout(listingId, buyerEmail, buyerPhone) {
       const list = load();
       const it = list.find(x=>x.id===listingId);
       if (!it) return alert("Listing not found."); if (it.remaining <= 0) return alert("Sold out.");
@@ -709,7 +722,7 @@
           const res = await fetch(`${API_BASE}/api/orders`, {
             method: "POST",
             headers: { "Content-Type":"application/json" },
-            body: JSON.stringify({ listingId, buyerEmail })
+            body: JSON.stringify({ listingId, buyerEmail, buyerPhone })
           });
           if (!res.ok) throw new Error("Order create failed");
           const data = await res.json();
@@ -723,11 +736,11 @@
       // Open seller's pay link in new tab (manual for MVP; replace with Stripe checkout later)
       if (it.pay && it.pay !== "#") window.open(it.pay, "_blank");
 
-      const order = { id: crypto.randomUUID(), shortId: Math.random().toString(36).slice(2,6).toUpperCase(), status: "authorized", authorizedAt: Date.now(), releasedAt: null, buyerEmail: buyerEmail || "" };
-      it.orders.push(order); it.remaining -= 1; save(list);
+      const order = { id: crypto.randomUUID(), token: crypto.randomUUID(), tokenExpiresAt: Date.now() + hoursMs(ESCROW_HOURS), status: "authorized", authorizedAt: Date.now(), releasedAt: null, buyerEmail, buyerPhone, sellerEmail: it.sellerEmail || "", sellerPhone: it.sellerPhone || "" };
+      it.orders.push(order); it.remaining -= 1; if (it.remaining <= 0) { delete it.sellerEmail; delete it.sellerPhone; } save(list);
       adminNotify("order_authorized_sim", it, order);
-      sellerNotify(it, "Ticket sold (authorized)", `Order ${order.shortId} for ${it.group} is authorized. Remember to transfer the ticket.`);
-      buyerNotify(it, order, "Purchase received – funds on hold", `We’ve placed your payment for order ${order.shortId} in escrow for up to 72 hours while the ticket is transferred.`);
+      sellerNotify(it, order, "Ticket sold (authorized)", `Order ${order.token.slice(0,8)} for ${it.group} is authorized. Remember to transfer the ticket.`);
+      buyerNotify(it, order, "Purchase received – funds on hold", `We’ve placed your payment for order ${order.token.slice(0,8)} in escrow for up to 72 hours while the ticket is transferred.`);
       applyFilters();
     }
     function confirmReceived(orderId) {
@@ -735,8 +748,9 @@
       outer: for (const it of list) { for (const o of it.orders) {
           if (o.id === orderId) { o.status = "released"; o.releasedAt = Date.now();
             adminNotify("order_released_manual_sim", it, o);
-            sellerNotify(it, "Funds released", `Order ${o.shortId} for ${it.group} has been released to you.`);
-            buyerNotify(it, o, "Escrow released", `Your confirmation released funds for order ${o.shortId}. Enjoy the show!`);
+            sellerNotify(it, o, "Funds released", `Order ${o.token.slice(0,8)} for ${it.group} has been released to you.`);
+            buyerNotify(it, o, "Escrow released", `Your confirmation released funds for order ${o.token.slice(0,8)}. Enjoy the show!`);
+            purgeOrder(o);
             break outer; } } }
       save(list); applyFilters();
     }
@@ -747,17 +761,21 @@
       let changed = false;
       for (const it of list) {
         for (const o of (it.orders||[])) {
+          const now = Date.now();
           if (o.status === "authorized") {
             const ms = timeLeftMs(o);
             if (ms <= 0) {
               o.status = "released";
-              o.releasedAt = Date.now();
+              o.releasedAt = now;
               adminNotify("order_released_auto", it, o);
-              sellerNotify(it, "Funds released (auto)", `Order ${o.shortId} for ${it.group} was auto-released after 72h.`);
-              buyerNotify(it, o, "Escrow auto-released", `Your order ${o.shortId} was auto-released after 72h.`);
+              sellerNotify(it, o, "Funds released (auto)", `Order ${o.token.slice(0,8)} for ${it.group} was auto-released after 72h.`);
+              buyerNotify(it, o, "Escrow auto-released", `Your order ${o.token.slice(0,8)} was auto-released after 72h.`);
+              purgeOrder(o);
               changed = true;
             }
           }
+          if (o.tokenExpiresAt && now > o.tokenExpiresAt) { purgeOrder(o); changed = true; }
+          if (o.releasedAt && now - o.releasedAt > RETENTION_MS) { purgeOrder(o); changed = true; }
         }
       }
       if (changed) save(list);
@@ -776,6 +794,11 @@
       applyFilters();
       const u = new URL(window.location.href); const manage = u.searchParams.get("manage") || "";
       if (manage) { const it = load().find(x=>x.editToken === manage); if (it) { fillManageForm(it); openManage(); } }
+      const orderToken = u.searchParams.get("order") || "";
+      if (orderToken) {
+        const list = load();
+        outer: for (const it of list) { for (const o of (it.orders||[])) { if (o.token === orderToken) { alert(`Order ${orderToken.slice(0,8)} status: ${o.status}`); break outer; } } }
+      }
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- require seller phone and buyer phone/email in transaction forms
- generate UUID order tokens for lookup links and drop short IDs
- purge contact data after release or token expiration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d733cfb08331af96aef7bcd7c03d