### PR TITLE
feat: add buyer checkout prompts

### DIFF
--- a/index.html
+++ b/index.html
@@ -737,12 +737,99 @@
 
     // ======= BUYER FLOW =======
     function openBuyerPrompt(listingId) {
+      const list = load();
+      const it = list.find(x=>x.id===listingId);
+      if (!it) return;
 
+      const buyerEmail = prompt("Enter your email for the seller:");
+      if (!buyerEmail) return;
+      const buyerPhone = prompt("Enter your phone number:");
+      if (!buyerPhone) return;
+
+      const form = document.getElementById("buyerForm");
+      form.reset();
+      form.elements["listingId"].value = listingId;
+
+      const header = document.querySelector("#buyerModal .gradient-brand");
+      if (header) {
+        header.innerHTML = `<h3 class="font-poppins text-xl">Buy ${it.group}</h3><p class="text-white/90 text-sm">${money(it.price)}</p>`;
+      }
+
+      const actions = form.querySelector("div.flex.items-center.justify-end.gap-2.pt-2");
+      if (actions) {
+        actions.innerHTML = `<button type="button" id="cancelBuyer" class="px-4 py-2 rounded-xl bg-gray-100 hover:bg-gray-200">Cancel</button><button class="px-5 py-2 rounded-xl text-white gradient-brand hover:opacity-90">Pay</button>`;
+        document.getElementById("cancelBuyer").addEventListener("click", closeBuyer, { once:true });
+      }
+
+      form.onsubmit = (e) => {
+        e.preventDefault();
+        startCheckout(listingId, buyerEmail.trim(), buyerPhone.trim());
+      };
+
+      if (typeof stripe === "undefined") {
+        stripe = Stripe(STRIPE_PK);
+      }
+      if (typeof card === "undefined") {
+        card = null;
+      }
+      openBuyer();
     }
     async function startCheckout(listingId, buyerEmail, buyerPhone) {
       const list = load();
       const it = list.find(x=>x.id===listingId);
+      if (!it) return;
 
+      let clientSecret = null;
+      let paymentIntentId = null;
+      if (API_BASE) {
+        try {
+          const res = await fetch(`${API_BASE}/api/create-intent`, {
+            method: "POST",
+            headers: { "Content-Type":"application/json" },
+            body: JSON.stringify({ amount: Math.round(Number(it.price) * 100) })
+          });
+          const data = await res.json();
+          if (!res.ok) throw new Error(data.error || "Payment error");
+          clientSecret = data.clientSecret;
+        } catch (err) {
+          alert(err.message);
+          return;
+        }
+      }
+      if (clientSecret) {
+        const result = await stripe.confirmCardPayment(clientSecret, {
+          payment_method: { card, billing_details: { email: buyerEmail } }
+        });
+        if (result.error) {
+          alert(result.error.message);
+          return;
+        }
+        paymentIntentId = result.paymentIntent.id;
+      }
+
+      const order = {
+        id: crypto.randomUUID(),
+        status: "authorized",
+        authorizedAt: Date.now(),
+        buyerEmail, buyerPhone,
+        sellerEmail: it.sellerEmail,
+        sellerPhone: it.sellerPhone,
+        pi: paymentIntentId,
+        token: token(),
+        tokenExpiresAt: Date.now() + hoursMs(ESCROW_HOURS)
+      };
+      if (!it.orders) it.orders = [];
+      it.orders.push(order);
+      it.remaining = Math.max(0, (it.remaining || it.qty || 0) - 1);
+      save(list);
+      applyFilters();
+      closeBuyer();
+
+      adminNotify("order_authorized", it, order);
+      sellerNotify(it, order, "Order Authorized", "A buyer has authorized payment. Please transfer the ticket and confirm.");
+      buyerNotify(it, order, "Payment Authorized", "Your payment is authorized. The seller will reach out with transfer details.");
+
+      alert("Payment authorized! You'll be contacted by the seller shortly.");
     }
     async function capturePayment(pi) {
       if (!API_BASE || !pi) return;


### PR DESCRIPTION
## Summary
- add buyer email/phone prompts and wire to checkout modal
- create payment intents and confirm payments via Stripe
- update listings with order status and send notifications on success

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c96053d88331946098644673bc55