### PR TITLE
Serve static frontend and document deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository only contains the frontend portion of FandomEntryPass. Backend A
    - FEP_PLATFORM_FEE_FLAT_CENTS = 350
    - FEP_SELLER_FEE_BPS = 500
    - ESCROW_HOURS = 72
-4. Ensure your deployment includes backend endpoints under `/api` and a database schema matching your environment variables.
+4. Ensure your deployment includes backend endpoints under `/api`, serves the frontend via Express static middleware (e.g., `app.use(express.static(__dirname))` so `/` returns `index.html`), and a database schema matching your environment variables.
 5. Your app is live at your Vercel URL. Add to home screen on phones for app experience.
 
 ## Frontend Configuration

--- a/server.js
+++ b/server.js
@@ -1,9 +1,16 @@
 const express = require('express');
+const path = require('path');
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 const db = require('./db');
 
 const app = express();
 app.use(express.json());
+app.use(express.static(__dirname));
+
+// Serve the main page
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
 
 const PLATFORM_FEE_PERCENT = 0.1; // 10%
 


### PR DESCRIPTION
## Summary
- Serve static assets and index.html from Express server
- Document static frontend serving in deployment steps

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cd21b6788331a3a5d95d15323cd4